### PR TITLE
대시보드 쿼리 속도 개선을 위한 Loki 쿼리 비동기 요청, 병렬 쿼리 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,7 @@ dependencies {
     testImplementation 'org.testcontainers:junit-jupiter:1.19.8'
     testImplementation "org.testcontainers:mysql:1.19.8"
     testImplementation group: 'io.projectreactor', name: 'reactor-test', version: '3.6.9'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-webtestclient'
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
 

--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,7 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers:1.19.8'
     testImplementation 'org.testcontainers:junit-jupiter:1.19.8'
     testImplementation "org.testcontainers:mysql:1.19.8"
+    testImplementation group: 'io.projectreactor', name: 'reactor-test', version: '3.6.9'
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
 

--- a/src/main/java/site/iris/issuefy/controller/DashBoardController.java
+++ b/src/main/java/site/iris/issuefy/controller/DashBoardController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
 import site.iris.issuefy.response.DashBoardResponse;
 import site.iris.issuefy.service.DashBoardService;
 
@@ -17,8 +18,9 @@ public class DashBoardController {
 	private final DashBoardService dashBoardService;
 
 	@GetMapping
-	public ResponseEntity<DashBoardResponse> dashboard(@RequestAttribute String githubId) {
-		DashBoardResponse dashBoardResponse = dashBoardService.getDashBoardFromLoki(githubId);
-		return ResponseEntity.ok().body(dashBoardResponse);
+	public Mono<ResponseEntity<DashBoardResponse>> dashboard(@RequestAttribute String githubId) {
+		return dashBoardService.getDashBoardFromLoki(githubId)
+			.map(dashBoardResponse -> ResponseEntity.ok().body(dashBoardResponse))
+			.defaultIfEmpty(ResponseEntity.notFound().build());
 	}
 }

--- a/src/main/java/site/iris/issuefy/model/dto/LokiQueryAddRepositoryDto.java
+++ b/src/main/java/site/iris/issuefy/model/dto/LokiQueryAddRepositoryDto.java
@@ -9,11 +9,13 @@ import lombok.Data;
 @Data
 public class LokiQueryAddRepositoryDto {
 	private String addRepositoryCount = "0";
+	private static final int COUNT_INDEX = 1;
+	private static final int FIRST_RESULT_INDEX = 0;
 
 	@JsonProperty("data")
 	private void unpackData(Data data) {
 		if (data.getResult() != null && !data.getResult().isEmpty()) {
-			addRepositoryCount = data.getResult().get(0).getValue().get(1);
+			addRepositoryCount = data.getResult().get(FIRST_RESULT_INDEX).getValue().get(COUNT_INDEX);
 		}
 	}
 

--- a/src/main/java/site/iris/issuefy/service/DashBoardService.java
+++ b/src/main/java/site/iris/issuefy/service/DashBoardService.java
@@ -50,8 +50,8 @@ public class DashBoardService {
 	}
 
 	private Mono<LokiQueryVisitDto> getNumberOfWeeklyVisit(String githubId, LocalDate startWeek, LocalDate endWeek) {
-		String maskGithubId = JwtAuthenticationFilter.maskId(githubId);
-		String rawLokiQuery = String.format(LokiQuery.NUMBER_OF_WEEKLY_VISIT.getQuery(), maskGithubId, startWeek,
+		String maskedGithubId = JwtAuthenticationFilter.maskId(githubId);
+		String rawLokiQuery = String.format(LokiQuery.NUMBER_OF_WEEKLY_VISIT.getQuery(), maskedGithubId, startWeek,
 			endWeek);
 		return webClient.get()
 			.uri(uriBuilder -> uriBuilder.path("/loki/api/v1/query")
@@ -65,8 +65,8 @@ public class DashBoardService {
 
 	private Mono<LokiQueryAddRepositoryDto> getNumberOfWeeklyRepositoryAdded(String githubId, LocalDate startWeek,
 		LocalDate endWeek) {
-		String maskGithubId = JwtAuthenticationFilter.maskId(githubId);
-		String rawLokiQuery = String.format(LokiQuery.NUMBER_OF_WEEKLY_REPOSITORY_ADDED.getQuery(), maskGithubId,
+		String maskedGithubId = JwtAuthenticationFilter.maskId(githubId);
+		String rawLokiQuery = String.format(LokiQuery.NUMBER_OF_WEEKLY_REPOSITORY_ADDED.getQuery(), maskedGithubId,
 			startWeek, endWeek);
 		return webClient.get()
 			.uri(uriBuilder -> uriBuilder.path("/loki/api/v1/query")
@@ -88,8 +88,8 @@ public class DashBoardService {
 		double addedRepos = Math.log(Double.parseDouble(addRepositoryCount) + 1) / Math.log(2);
 
 		// 정규화 과정
-		double normalizedVisits = Math.min(visits / 10, 1);
-		double normalizedRepos = Math.min(addedRepos / 7, 1);
+		double normalizedVisits = Math.min(visits / 30, 1);
+		double normalizedRepos = Math.min(addedRepos / 25, 1);
 
 		double rawScore = (normalizedVisits * VISIT_WEIGHT + normalizedRepos * REPOSITORY_WEIGHT) * MAX_SCORE;
 		return (int)Math.min(rawScore, MAX_SCORE);

--- a/src/main/java/site/iris/issuefy/service/DashBoardService.java
+++ b/src/main/java/site/iris/issuefy/service/DashBoardService.java
@@ -1,17 +1,15 @@
 package site.iris.issuefy.service;
 
 import java.time.LocalDate;
-import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
 import site.iris.issuefy.eums.DashBoardRank;
-import site.iris.issuefy.eums.ErrorCode;
 import site.iris.issuefy.eums.LokiQuery;
-import site.iris.issuefy.exception.network.LokiException;
 import site.iris.issuefy.filter.JwtAuthenticationFilter;
 import site.iris.issuefy.model.dto.LokiQueryAddRepositoryDto;
 import site.iris.issuefy.model.dto.LokiQueryVisitDto;
@@ -30,57 +28,54 @@ public class DashBoardService {
 		this.webClient = webClient;
 	}
 
-	public DashBoardResponse getDashBoardFromLoki(String githubId) {
-		ErrorCode lokiError = ErrorCode.LOKI_EXCEPTION;
+	public Mono<DashBoardResponse> getDashBoardFromLoki(String githubId) {
 		LocalDate today = LocalDate.now();
 		LocalDate startWeek = today.minusDays(MINUS_DAYS);
 
-		String visitCount = Optional.ofNullable(getNumberOfWeeklyVisit(githubId, lokiError, startWeek, today))
+		Mono<String> visitCountMono = getNumberOfWeeklyVisit(githubId, startWeek, today)
 			.map(LokiQueryVisitDto::getVisitCount)
-			.orElse("0");
-		String addRepositoryCount = Optional.ofNullable(
-				getNumberOfWeeklyRepositoryAdded(githubId, lokiError, startWeek, today))
-			.map(LokiQueryAddRepositoryDto::getAddRepositoryCount)
-			.orElse("0");
-		String rank = calculateRank(visitCount, addRepositoryCount);
+			.defaultIfEmpty("0");
 
-		return DashBoardResponse.of(startWeek, today, rank, visitCount, addRepositoryCount);
+		Mono<String> addRepositoryCountMono = getNumberOfWeeklyRepositoryAdded(githubId, startWeek, today)
+			.map(LokiQueryAddRepositoryDto::getAddRepositoryCount)
+			.defaultIfEmpty("0");
+
+		return Mono.zip(visitCountMono, addRepositoryCountMono)
+			.map(tuple -> {
+				String visitCount = tuple.getT1();
+				String addRepositoryCount = tuple.getT2();
+				String rank = calculateRank(visitCount, addRepositoryCount);
+				return DashBoardResponse.of(startWeek, today, rank, visitCount, addRepositoryCount);
+			});
 	}
 
-	private LokiQueryVisitDto getNumberOfWeeklyVisit(String githubId, ErrorCode lokiError, LocalDate startWeek,
-		LocalDate endWeek) {
+	private Mono<LokiQueryVisitDto> getNumberOfWeeklyVisit(String githubId, LocalDate startWeek, LocalDate endWeek) {
 		String maskGithubId = JwtAuthenticationFilter.maskId(githubId);
 		String rawLokiQuery = String.format(LokiQuery.NUMBER_OF_WEEKLY_VISIT.getQuery(), maskGithubId, startWeek,
 			endWeek);
-		try {
-			return webClient.get()
-				.uri(uriBuilder -> uriBuilder.path("/loki/api/v1/query")
-					.queryParam("query", "{query}")
-					.build(rawLokiQuery))
-				.retrieve()
-				.bodyToMono(LokiQueryVisitDto.class)
-				.block();
-		} catch (Exception e) {
-			throw new LokiException(lokiError.getMessage(), lokiError.getStatus());
-		}
+		return webClient.get()
+			.uri(uriBuilder -> uriBuilder.path("/loki/api/v1/query")
+				.queryParam("query", "{query}")
+				.build(rawLokiQuery))
+			.retrieve()
+			.bodyToMono(LokiQueryVisitDto.class)
+			.doOnError(e -> log.error("Error fetching weekly visit count: {}", e.getMessage()))
+			.onErrorResume(e -> Mono.empty());
 	}
 
-	private LokiQueryAddRepositoryDto getNumberOfWeeklyRepositoryAdded(String githubId, ErrorCode lokiError,
-		LocalDate startWeek, LocalDate endWeek) {
+	private Mono<LokiQueryAddRepositoryDto> getNumberOfWeeklyRepositoryAdded(String githubId, LocalDate startWeek,
+		LocalDate endWeek) {
 		String maskGithubId = JwtAuthenticationFilter.maskId(githubId);
 		String rawLokiQuery = String.format(LokiQuery.NUMBER_OF_WEEKLY_REPOSITORY_ADDED.getQuery(), maskGithubId,
 			startWeek, endWeek);
-		try {
-			return webClient.get()
-				.uri(uriBuilder -> uriBuilder.path("/loki/api/v1/query")
-					.queryParam("query", "{query}")
-					.build(rawLokiQuery))
-				.retrieve()
-				.bodyToMono(LokiQueryAddRepositoryDto.class)
-				.block();
-		} catch (Exception e) {
-			throw new LokiException(lokiError.getMessage(), lokiError.getStatus());
-		}
+		return webClient.get()
+			.uri(uriBuilder -> uriBuilder.path("/loki/api/v1/query")
+				.queryParam("query", "{query}")
+				.build(rawLokiQuery))
+			.retrieve()
+			.bodyToMono(LokiQueryAddRepositoryDto.class)
+			.doOnError(e -> log.error("Error fetching weekly repository add count: {}", e.getMessage()))
+			.onErrorResume(e -> Mono.empty());
 	}
 
 	private String calculateRank(String visitCount, String addRepositoryCount) {

--- a/src/test/java/site/iris/issuefy/controller/DashBoardControllerTest.java
+++ b/src/test/java/site/iris/issuefy/controller/DashBoardControllerTest.java
@@ -2,68 +2,70 @@ package site.iris.issuefy.controller;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
-import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.time.LocalDate;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.restdocs.RestDocumentationExtension;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.context.WebApplicationContext;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
 
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
 import site.iris.issuefy.response.DashBoardResponse;
 import site.iris.issuefy.service.DashBoardService;
 
+@Slf4j
 @ExtendWith(RestDocumentationExtension.class)
-@WebMvcTest(DashBoardController.class)
+@WebFluxTest(controllers = DashBoardController.class)
+@Import(DashBoardControllerTest.TestSecurityConfig.class)
 @AutoConfigureRestDocs
 class DashBoardControllerTest {
 
 	@Autowired
-	private MockMvc mockMvc;
+	private WebTestClient webTestClient;
 
 	@MockBean
 	private DashBoardService dashBoardService;
 
-	@BeforeEach
-	public void setUp(WebApplicationContext webApplicationContext,
-		RestDocumentationContextProvider restDocumentation) {
-		this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
-			.apply(documentationConfiguration(restDocumentation))
-			.build();
-	}
-
 	@Test
 	@DisplayName("대시보드에 필요한 랭크, 주간방문수, 리포지토리 추가 횟수를 반환한다.")
-	void dashboard() throws Exception {
+	void dashboard() {
 		LocalDate endDate = LocalDate.now();
 		LocalDate startDate = endDate.minusDays(6);
 		DashBoardResponse mockResponse = DashBoardResponse.of(startDate, endDate, "A", "10", "5");
 
-		when(dashBoardService.getDashBoardFromLoki(anyString())).thenReturn(mockResponse);
+		when(dashBoardService.getDashBoardFromLoki(anyString())).thenReturn(Mono.just(mockResponse));
 
-		this.mockMvc.perform(get("/api/dashboard")
-				.requestAttr("githubId", "testUser"))
-			.andExpect(status().isOk())
-			.andDo(document("dashboard",
-				responseFields(
-					fieldWithPath("startDate").description("Start date of the dashboard data"),
-					fieldWithPath("endDate").description("End date of the dashboard data"),
-					fieldWithPath("rank").description("User's rank based on activity"),
-					fieldWithPath("visitCount").description("Number of visits in the last week"),
-					fieldWithPath("addRepositoryCount").description("Number of repositories added in the last week")
-				)));
+		webTestClient.get().uri("/api/dashboard")
+			.header("Authorization", "Bearer mockJwtToken")
+			.exchange()
+			.expectStatus().isOk()
+			.expectBody()
+			.jsonPath("$.startDate").isEqualTo(startDate.toString())
+			.jsonPath("$.endDate").isEqualTo(endDate.toString())
+			.jsonPath("$.rank").isEqualTo("A")
+			.jsonPath("$.visitCount").isEqualTo("10")
+			.jsonPath("$.addRepositoryCount").isEqualTo("5");
+	}
+
+	static class TestSecurityConfig {
+		@Bean
+		public WebFilter mockJwtFilter() {
+			return (ServerWebExchange exchange, WebFilterChain chain) -> {
+				exchange.getAttributes().put("githubId", "testUser");
+				return chain.filter(exchange);
+			};
+		}
 	}
 }

--- a/src/test/java/site/iris/issuefy/controller/DashBoardControllerTest.java
+++ b/src/test/java/site/iris/issuefy/controller/DashBoardControllerTest.java
@@ -2,6 +2,8 @@ package site.iris.issuefy.controller;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.*;
 
 import java.time.LocalDate;
 
@@ -52,6 +54,15 @@ class DashBoardControllerTest {
 			.exchange()
 			.expectStatus().isOk()
 			.expectBody()
+			.consumeWith(document("dashboard",
+				responseFields(
+					fieldWithPath("startDate").description("대시보드 시작 날짜"),
+					fieldWithPath("endDate").description("대시보드 종료 날짜"),
+					fieldWithPath("rank").description("사용자 랭크"),
+					fieldWithPath("visitCount").description("주간 방문 수"),
+					fieldWithPath("addRepositoryCount").description("리포지토리 추가 횟수")
+				)
+			))
 			.jsonPath("$.startDate").isEqualTo(startDate.toString())
 			.jsonPath("$.endDate").isEqualTo(endDate.toString())
 			.jsonPath("$.rank").isEqualTo("A")

--- a/src/test/java/site/iris/issuefy/service/DashBoardServiceTest.java
+++ b/src/test/java/site/iris/issuefy/service/DashBoardServiceTest.java
@@ -8,6 +8,7 @@ import java.time.LocalDate;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.reactive.function.client.WebClient;
 
@@ -47,6 +48,7 @@ class DashBoardServiceTest {
     }
 
     @Test
+    @DisplayName("Loki에서 대시보드 정보를 정상적으로 가져오는지 테스트한다.")
     void getDashBoardFromLoki_ShouldReturnCorrectResponse() throws Exception {
         // Given
         LokiQueryVisitDto visitDto = new LokiQueryVisitDto();
@@ -82,6 +84,7 @@ class DashBoardServiceTest {
     }
 
     @Test
+    @DisplayName("Loki에서 빈 응답을 받았을 때 올바르게 처리하는지 테스트한다.")
     void getDashBoardFromLoki_ShouldHandleEmptyResponses() {
         // Given
         mockWebServer.enqueue(new MockResponse()
@@ -109,6 +112,7 @@ class DashBoardServiceTest {
     }
 
     @Test
+    @DisplayName("Loki에서 오류 응답을 받았을 때 올바르게 처리하는지 테스트한다.")
     void getDashBoardFromLoki_ShouldHandleErrorResponses() {
         // Given
         mockWebServer.enqueue(new MockResponse().setResponseCode(500));

--- a/src/test/java/site/iris/issuefy/service/DashBoardServiceTest.java
+++ b/src/test/java/site/iris/issuefy/service/DashBoardServiceTest.java
@@ -82,7 +82,7 @@ class DashBoardServiceTest {
     }
 
     @Test
-    void getDashBoardFromLoki_ShouldHandleEmptyResponses() throws Exception {
+    void getDashBoardFromLoki_ShouldHandleEmptyResponses() {
         // Given
         mockWebServer.enqueue(new MockResponse()
                 .setBody("{}")

--- a/src/test/java/site/iris/issuefy/service/DashBoardServiceTest.java
+++ b/src/test/java/site/iris/issuefy/service/DashBoardServiceTest.java
@@ -1,47 +1,133 @@
 package site.iris.issuefy.service;
 
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
 
+import java.io.IOException;
 import java.time.LocalDate;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.reactive.function.client.WebClient;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
+import site.iris.issuefy.model.dto.LokiQueryAddRepositoryDto;
+import site.iris.issuefy.model.dto.LokiQueryVisitDto;
 import site.iris.issuefy.response.DashBoardResponse;
 
-@ExtendWith(MockitoExtension.class)
 class DashBoardServiceTest {
 
-	@Mock
-	private DashBoardService dashBoardService;
+    private static MockWebServer mockWebServer;
+    private DashBoardService dashBoardService;
+    private ObjectMapper objectMapper;
 
-	private final LocalDate fixedDate = LocalDate.of(2024, 9, 16);
+    @BeforeAll
+    static void setUp() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+    }
 
-	@BeforeEach
-	void setUp() {
-	}
+    @AfterAll
+    static void tearDown() throws IOException {
+        mockWebServer.shutdown();
+    }
 
-	@Test
-	void getDashBoardFromLoki_ShouldReturnCorrectResponse() {
-		// Given
-		DashBoardResponse mockResponse = new DashBoardResponse(
-			fixedDate.minusDays(6),
-			fixedDate,
-			"A",
-			"10",
-			"5"
-		);
-		when(dashBoardService.getDashBoardFromLoki(any())).thenReturn(Mono.just(mockResponse));
+    @BeforeEach
+    void initialize() {
+        String baseUrl = String.format("http://localhost:%s", mockWebServer.getPort());
+        WebClient webClient = WebClient.create(baseUrl);
+        dashBoardService = new DashBoardService(webClient);
+        objectMapper = new ObjectMapper();
+    }
 
-		// When & Then
-		StepVerifier.create(dashBoardService.getDashBoardFromLoki("testUser"))
-			.expectNext(mockResponse)
-			.verifyComplete();
-	}
+    @Test
+    void getDashBoardFromLoki_ShouldReturnCorrectResponse() throws Exception {
+        // Given
+        LokiQueryVisitDto visitDto = new LokiQueryVisitDto();
+        visitDto.setVisitCount("10");
+        String visitJson = objectMapper.writeValueAsString(visitDto);
+
+        LokiQueryAddRepositoryDto repoDto = new LokiQueryAddRepositoryDto();
+        repoDto.setAddRepositoryCount("5");
+        String repoJson = objectMapper.writeValueAsString(repoDto);
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody(visitJson)
+                .addHeader("Content-Type", "application/json"));
+        mockWebServer.enqueue(new MockResponse()
+                .setBody(repoJson)
+                .addHeader("Content-Type", "application/json"));
+
+        // When
+        Mono<DashBoardResponse> result = dashBoardService.getDashBoardFromLoki("testUser");
+
+        // Then
+        StepVerifier.create(result)
+                .expectNextMatches(response -> {
+                    assertEquals("10", response.getVisitCount());
+                    assertEquals("5", response.getAddRepositoryCount());
+                    assertNotNull(response.getRank());
+                    LocalDate today = LocalDate.now();
+                    assertEquals(today.minusDays(6), response.getStartDate());
+                    assertEquals(today, response.getEndDate());
+                    return true;
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void getDashBoardFromLoki_ShouldHandleEmptyResponses() throws Exception {
+        // Given
+        mockWebServer.enqueue(new MockResponse()
+                .setBody("{}")
+                .addHeader("Content-Type", "application/json"));
+        mockWebServer.enqueue(new MockResponse()
+                .setBody("{}")
+                .addHeader("Content-Type", "application/json"));
+
+        // When
+        Mono<DashBoardResponse> result = dashBoardService.getDashBoardFromLoki("testUser");
+
+        // Then
+        StepVerifier.create(result)
+                .expectNextMatches(response -> {
+                    assertEquals("0", response.getVisitCount());
+                    assertEquals("0", response.getAddRepositoryCount());
+                    assertNotNull(response.getRank());
+                    LocalDate today = LocalDate.now();
+                    assertEquals(today.minusDays(6), response.getStartDate());
+                    assertEquals(today, response.getEndDate());
+                    return true;
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void getDashBoardFromLoki_ShouldHandleErrorResponses() {
+        // Given
+        mockWebServer.enqueue(new MockResponse().setResponseCode(500));
+        mockWebServer.enqueue(new MockResponse().setResponseCode(500));
+
+        // When
+        Mono<DashBoardResponse> result = dashBoardService.getDashBoardFromLoki("testUser");
+
+        // Then
+        StepVerifier.create(result)
+                .expectNextMatches(response -> {
+                    assertEquals("0", response.getVisitCount());
+                    assertEquals("0", response.getAddRepositoryCount());
+                    assertNotNull(response.getRank());
+                    LocalDate today = LocalDate.now();
+                    assertEquals(today.minusDays(6), response.getStartDate());
+                    assertEquals(today, response.getEndDate());
+                    return true;
+                })
+                .verifyComplete();
+    }
 }


### PR DESCRIPTION
## 🚀 개요

<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

* 대시보드의 쿼리 속도 개선을 위해 Loki 쿼리를 비동기 요청으로 변경하고 2개의 쿼리 병렬 실행으로 수정하였습니다.
* LokiQueryAddRepositoryDto 매직넘버를 제거하여 가독성을 높혔습니다.
* maskedGithubId로 변수명 변경 및 랭크 정규화 상한선을 높혔습니다.


Issue-ID: __issuefy-##__

## 📗 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 🔎 상세 내용

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
